### PR TITLE
docs: add funding information

### DIFF
--- a/.github/FUNDING.md
+++ b/.github/FUNDING.md
@@ -1,0 +1,28 @@
+# Funding
+
+If you find this project useful and would like to support its development, you can help in several ways:
+
+## GitHub Sponsors
+You can sponsor me directly through GitHub Sponsors:
+- [Sponsor @d0ugal on GitHub](https://github.com/sponsors/d0ugal)
+
+## One-time Donations
+- **Ko-fi**: [Buy me a coffee](https://ko-fi.com/d0ugal)
+- **PayPal**: [PayPal.me/d0ugal](https://paypal.me/d0ugal)
+
+## Other Ways to Support
+- ⭐ **Star the repository** - Show your appreciation
+- 🐛 **Report bugs** - Help improve the project
+- 💡 **Suggest features** - Contribute ideas
+- 📖 **Improve documentation** - Help others use the project
+- 🔧 **Submit pull requests** - Contribute code improvements
+
+## What Your Support Enables
+Your support helps me:
+- Maintain and improve existing exporters
+- Develop new Prometheus exporters
+- Keep dependencies up to date
+- Provide timely bug fixes and feature updates
+- Write better documentation and examples
+
+Thank you for considering supporting this project! 🙏


### PR DESCRIPTION
Add .github/FUNDING.md file to enable GitHub funding features.

This file allows GitHub to display funding options including:
- GitHub Sponsors
- Ko-fi donations  
- PayPal donations
- Other ways to support the project

The funding information helps users understand how they can support the development and maintenance of this exporter.