### PR TITLE
feat(renovate): add docs commit message format for documentation updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,20 @@
       enabled: true,
     },
     {
+      // Use docs commit message format for documentation updates
+      matchManagers: [
+        'regex',
+      ],
+      matchFileNames: [
+        '**/*.md',
+        '**/docker-compose*.yml',
+        '**/docker-compose*.yaml',
+      ],
+      commitMessagePrefix: 'docs:',
+      commitMessageAction: 'update',
+      commitMessageTopic: 'documentation versions',
+    },
+    {
       // Auto-run go mod tidy for Go module updates
       matchManagers: [
         'gomod',
@@ -51,6 +65,18 @@
         'GOLANGCI_LINT_VERSION := (?<currentValue>v[\\d\\.]+)',
       ],
       depNameTemplate: 'golangci/golangci-lint',
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'semver',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '**/*.md',
+      ],
+      matchStrings: [
+        'ghcr\\.io/d0ugal/brother-exporter:(?<currentValue>v[\\d\\.]+)',
+      ],
+      depNameTemplate: 'ghcr.io/d0ugal/brother-exporter',
       datasourceTemplate: 'docker',
       versioningTemplate: 'semver',
     },


### PR DESCRIPTION
## Docs Commit Message Format

This PR configures Renovate to use docs: commit message prefix for documentation updates.

### Changes:
- ✅ Add packageRule to use docs: prefix for markdown and docker-compose files
- ✅ Configure commitMessageAction: update and commitMessageTopic: documentation versions
- ✅ Target files: **/*.md, **/docker-compose*.yml, **/docker-compose*.yaml

### Benefits:
- 🎯 Clearer commit history with docs: prefix for documentation changes
- 📝 Better organization of commit messages by type
- 🔍 Easier filtering of documentation-related commits
- 📚 Improved maintainability of documentation updates

### Example Commit Messages:
- docs: update documentation versions
- docs: update mqtt-exporter to v1.14.0
- docs: update docker-compose examples to v2.0.7