### PR TITLE
fix: make yaml optional and always overlay env vars on config

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -13,4 +13,3 @@ jobs:
           fetch-depth: 0
 
       - uses: aevea/commitsar@909c3ab676c9af63cb84f2e38f395c7e89829b04 # v1.0.3
-

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,28 +15,6 @@ import (
 	promexporter_metrics "github.com/d0ugal/promexporter/metrics"
 )
 
-// hasEnvironmentVariables checks if any BROTHER_EXPORTER_* environment variables are set
-func hasEnvironmentVariables() bool {
-	envVars := []string{
-		"BROTHER_EXPORTER_SERVER_HOST",
-		"BROTHER_EXPORTER_SERVER_PORT",
-		"BROTHER_EXPORTER_LOG_LEVEL",
-		"BROTHER_EXPORTER_LOG_FORMAT",
-		"BROTHER_EXPORTER_METRICS_DEFAULT_INTERVAL",
-		"BROTHER_EXPORTER_PRINTER_HOST",
-		"BROTHER_EXPORTER_PRINTER_COMMUNITY",
-		"BROTHER_EXPORTER_PRINTER_TYPE",
-	}
-
-	for _, envVar := range envVars {
-		if os.Getenv(envVar) != "" {
-			return true
-		}
-	}
-
-	return false
-}
-
 func main() {
 	// Parse command line flags
 	var showVersion bool
@@ -49,7 +27,7 @@ func main() {
 	)
 
 	flag.StringVar(&configPath, "config", "config.yaml", "Path to configuration file")
-	flag.BoolVar(&configFromEnv, "config-from-env", false, "Load configuration from environment variables only")
+	flag.BoolVar(&configFromEnv, "config-from-env", false, "Deprecated: env vars are always applied; this flag is a no-op")
 	flag.Parse()
 
 	// Show version if requested
@@ -60,26 +38,17 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Use environment variable if config flag is not provided
-	if configPath == "config.yaml" && !configFromEnv {
+	if configPath == "config.yaml" {
 		if envConfig := os.Getenv("CONFIG_PATH"); envConfig != "" {
 			configPath = envConfig
 		}
 	}
 
-	// Check if we should use environment-only configuration
-	if !configFromEnv {
-		// Check explicit flag first
-		if os.Getenv("BROTHER_EXPORTER_CONFIG_FROM_ENV") == "true" {
-			configFromEnv = true
-		} else if hasEnvironmentVariables() {
-			// Auto-detect environment variables and use them
-			configFromEnv = true
-		}
+	if configFromEnv || os.Getenv("BROTHER_EXPORTER_CONFIG_FROM_ENV") == "true" {
+		fmt.Fprintln(os.Stderr, "Warning: --config-from-env / BROTHER_EXPORTER_CONFIG_FROM_ENV is deprecated and has no effect. Env vars are always applied on top of yaml config.")
 	}
 
-	// Load configuration
-	cfg, err := config.LoadConfig(configPath, configFromEnv)
+	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
 		slog.Error("Failed to load configuration", "error", err)
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,123 +25,69 @@ type PrinterConfig struct {
 	Interfaces []string `yaml:"interfaces"`
 }
 
-// LoadConfig loads configuration from either a YAML file or environment variables
-func LoadConfig(path string, configFromEnv bool) (*Config, error) {
-	if configFromEnv {
-		return loadFromEnv()
-	}
+// LoadConfig loads configuration with priority: env vars > yaml file > defaults.
+// The yaml file is optional; if path is empty or the file does not exist it is
+// silently skipped. Environment variables are always applied on top.
+func LoadConfig(path string) (*Config, error) {
+	var cfg Config
 
-	return Load(path)
-}
-
-// Load loads configuration from a YAML file
-func Load(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config file: %w", err)
-	}
-
-	var config Config
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
-	}
-
-	// Set defaults
-	setDefaults(&config)
-
-	// Validate configuration
-	if err := config.Validate(); err != nil {
-		return nil, fmt.Errorf("configuration validation failed: %w", err)
-	}
-
-	return &config, nil
-}
-
-// loadFromEnv loads configuration from environment variables
-func loadFromEnv() (*Config, error) {
-	config := &Config{}
-
-	// Load base configuration from environment
-	baseConfig := &promexporter_config.BaseConfig{}
-
-	// Server configuration
-	if host := os.Getenv("BROTHER_EXPORTER_SERVER_HOST"); host != "" {
-		baseConfig.Server.Host = host
-	} else {
-		baseConfig.Server.Host = "0.0.0.0"
-	}
-
-	if portStr := os.Getenv("BROTHER_EXPORTER_SERVER_PORT"); portStr != "" {
-		if port, err := parseInt(portStr); err != nil {
-			return nil, fmt.Errorf("invalid server port: %w", err)
-		} else {
-			baseConfig.Server.Port = port
+	if path != "" {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
+			}
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
 		}
-	} else {
-		baseConfig.Server.Port = 8080
 	}
 
-	// Logging configuration
-	if level := os.Getenv("BROTHER_EXPORTER_LOG_LEVEL"); level != "" {
-		baseConfig.Logging.Level = level
-	} else {
-		baseConfig.Logging.Level = "info"
-	}
-
-	if format := os.Getenv("BROTHER_EXPORTER_LOG_FORMAT"); format != "" {
-		baseConfig.Logging.Format = format
-	} else {
-		baseConfig.Logging.Format = "json"
-	}
-
-	// Metrics configuration
-	if intervalStr := os.Getenv("BROTHER_EXPORTER_METRICS_DEFAULT_INTERVAL"); intervalStr != "" {
-		if interval, err := time.ParseDuration(intervalStr); err != nil {
-			return nil, fmt.Errorf("invalid metrics default interval: %w", err)
-		} else {
-			baseConfig.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
-			baseConfig.Metrics.Collection.DefaultIntervalSet = true
-		}
-	} else {
-		baseConfig.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: time.Second * 30}
-	}
-
-	config.BaseConfig = *baseConfig
-
-	// Apply generic environment variables (TRACING_ENABLED, PROFILING_ENABLED, etc.)
-	// These are handled by promexporter and are shared across all exporters
-	if err := promexporter_config.ApplyGenericEnvVars(&config.BaseConfig); err != nil {
+	if err := promexporter_config.ApplyGenericEnvVars(&cfg.BaseConfig); err != nil {
 		return nil, fmt.Errorf("failed to apply generic environment variables: %w", err)
 	}
 
-	// Printer configuration
-	if host := os.Getenv("BROTHER_EXPORTER_PRINTER_HOST"); host != "" {
-		config.Printer.Host = host
-	} else {
-		config.Printer.Host = "192.168.1.100"
-	}
+	applyEnvVars(&cfg)
+	setDefaults(&cfg)
 
-	if community := os.Getenv("BROTHER_EXPORTER_PRINTER_COMMUNITY"); community != "" {
-		config.Printer.Community = community
-	} else {
-		config.Printer.Community = "public"
-	}
-
-	if printerType := os.Getenv("BROTHER_EXPORTER_PRINTER_TYPE"); printerType != "" {
-		config.Printer.Type = printerType
-	} else {
-		config.Printer.Type = "laser"
-	}
-
-	// Set defaults for any missing values
-	setDefaults(config)
-
-	// Validate configuration
-	if err := config.Validate(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
 	}
 
-	return config, nil
+	return &cfg, nil
+}
+
+// applyEnvVars overlays Brother-exporter environment variables onto cfg.
+// Only variables that are set (non-empty) are applied.
+func applyEnvVars(cfg *Config) {
+	if host := os.Getenv("BROTHER_EXPORTER_SERVER_HOST"); host != "" {
+		cfg.Server.Host = host
+	}
+	if portStr := os.Getenv("BROTHER_EXPORTER_SERVER_PORT"); portStr != "" {
+		if port, err := parseInt(portStr); err == nil {
+			cfg.Server.Port = port
+		}
+	}
+	if level := os.Getenv("BROTHER_EXPORTER_LOG_LEVEL"); level != "" {
+		cfg.Logging.Level = level
+	}
+	if format := os.Getenv("BROTHER_EXPORTER_LOG_FORMAT"); format != "" {
+		cfg.Logging.Format = format
+	}
+	if intervalStr := os.Getenv("BROTHER_EXPORTER_METRICS_DEFAULT_INTERVAL"); intervalStr != "" {
+		if interval, err := time.ParseDuration(intervalStr); err == nil {
+			cfg.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
+			cfg.Metrics.Collection.DefaultIntervalSet = true
+		}
+	}
+	if host := os.Getenv("BROTHER_EXPORTER_PRINTER_HOST"); host != "" {
+		cfg.Printer.Host = host
+	}
+	if community := os.Getenv("BROTHER_EXPORTER_PRINTER_COMMUNITY"); community != "" {
+		cfg.Printer.Community = community
+	}
+	if printerType := os.Getenv("BROTHER_EXPORTER_PRINTER_TYPE"); printerType != "" {
+		cfg.Printer.Type = printerType
+	}
 }
 
 // parseInt parses a string to int

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,29 +62,36 @@ func applyEnvVars(cfg *Config) {
 	if host := os.Getenv("BROTHER_EXPORTER_SERVER_HOST"); host != "" {
 		cfg.Server.Host = host
 	}
+
 	if portStr := os.Getenv("BROTHER_EXPORTER_SERVER_PORT"); portStr != "" {
 		if port, err := parseInt(portStr); err == nil {
 			cfg.Server.Port = port
 		}
 	}
+
 	if level := os.Getenv("BROTHER_EXPORTER_LOG_LEVEL"); level != "" {
 		cfg.Logging.Level = level
 	}
+
 	if format := os.Getenv("BROTHER_EXPORTER_LOG_FORMAT"); format != "" {
 		cfg.Logging.Format = format
 	}
+
 	if intervalStr := os.Getenv("BROTHER_EXPORTER_METRICS_DEFAULT_INTERVAL"); intervalStr != "" {
 		if interval, err := time.ParseDuration(intervalStr); err == nil {
 			cfg.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
 			cfg.Metrics.Collection.DefaultIntervalSet = true
 		}
 	}
+
 	if host := os.Getenv("BROTHER_EXPORTER_PRINTER_HOST"); host != "" {
 		cfg.Printer.Host = host
 	}
+
 	if community := os.Getenv("BROTHER_EXPORTER_PRINTER_COMMUNITY"); community != "" {
 		cfg.Printer.Community = community
 	}
+
 	if printerType := os.Getenv("BROTHER_EXPORTER_PRINTER_TYPE"); printerType != "" {
 		cfg.Printer.Type = printerType
 	}


### PR DESCRIPTION
Env vars now always apply on top of yaml (env > yaml > defaults). yaml is optional. --config-from-env deprecated as no-op.