### PR TITLE
fix: align PrinterConnectionErrors label with registered name

### DIFF
--- a/internal/collectors/brother_collector.go
+++ b/internal/collectors/brother_collector.go
@@ -106,8 +106,8 @@ func (bc *BrotherCollector) handleCollectionError(err error, operation string) {
 	if err != nil {
 		slog.Error("Failed to collect "+operation, "error", err)
 		bc.metrics.PrinterConnectionErrors.With(prometheus.Labels{
-			"host":      bc.config.Printer.Host,
-			"operation": operation,
+			"host":       bc.config.Printer.Host,
+			"error_type": operation,
 		}).Inc()
 	}
 }
@@ -350,8 +350,8 @@ func (bc *BrotherCollector) collectMetrics(ctx context.Context) {
 			"host": bc.config.Printer.Host,
 		}).Set(0)
 		bc.metrics.PrinterConnectionErrors.With(prometheus.Labels{
-			"host":      bc.config.Printer.Host,
-			"operation": "connect",
+			"host":       bc.config.Printer.Host,
+			"error_type": "connect",
 		}).Inc()
 
 		return


### PR DESCRIPTION
## Summary
- The metric \`brother_printer_connection_errors_total\` is registered in \`internal/metrics/brother_registry.go:88-94\` with labels \`[host, error_type]\`, but every call site in \`brother_collector.go\` was using \`[host, operation]\`.
- \`prometheus.Labels.With()\` panics when the supplied label set doesn't match the metric's registered label dimension, so the very first connect failure or SNMP error path would crash the exporter.
- This PR renames the call-site label key from \`operation\` to \`error_type\`, matching the registry.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [ ] Verify on a real printer: trigger a connect failure (e.g. wrong host) and confirm the exporter no longer panics and the \`brother_printer_connection_errors_total{error_type="connect"}\` series appears.