### PR TITLE
chore: remove deprecated --config-from-env flag and env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,13 +21,9 @@ func main() {
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.BoolVar(&showVersion, "v", false, "Show version information")
 
-	var (
-		configPath    string
-		configFromEnv bool
-	)
+	var configPath string
 
 	flag.StringVar(&configPath, "config", "config.yaml", "Path to configuration file")
-	flag.BoolVar(&configFromEnv, "config-from-env", false, "Deprecated: env vars are always applied; this flag is a no-op")
 	flag.Parse()
 
 	// Show version if requested
@@ -42,10 +38,6 @@ func main() {
 		if envConfig := os.Getenv("CONFIG_PATH"); envConfig != "" {
 			configPath = envConfig
 		}
-	}
-
-	if configFromEnv || os.Getenv("BROTHER_EXPORTER_CONFIG_FROM_ENV") == "true" {
-		fmt.Fprintln(os.Stderr, "Warning: --config-from-env / BROTHER_EXPORTER_CONFIG_FROM_ENV is deprecated and has no effect. Env vars are always applied on top of yaml config.")
 	}
 
 	cfg, err := config.LoadConfig(configPath)


### PR DESCRIPTION
## Summary
The flag and env var have been documented as deprecated/no-op for several releases. Env vars are always applied on top of yaml config unconditionally, so the deprecation warning is the only thing this code does.

Drop the flag, the var, and the warning block.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`